### PR TITLE
feat: add shadow dom

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,10 @@ Web Component version of FitVids from the creator of FitVids. This will make you
 
 ## Features
 
-Supported video vendors:
+Supports YouTube, Vimeo, and any other `iframe` video embed.
 
-- [x] YouTube
-- [x] Vimeo
+It's also v smol 889 bytes (482b gzipped)
 
-It's also v smol:
-
-|  | Bytes |
-|---|---|
-|Size         | 727 bytes |
-| Gzipped      | 419 bytes |
 
 ## Usage
 
@@ -28,12 +21,6 @@ Import the custom element and wrap your videos.
   <iframe src="http://youtube.com?v=123"></iframe>
 </fit-vids>
 ```
-
-## Roadmap/Todo
-
-- [ ] Allow more/custom sources? (e.g. tiktok, etc)
-- [ ] Prop to disable default `width: 100%`? Or set width/max-width to `video.width` by default?
-- [ ] ShadowDOM?
 
 ## Acknowledgements
 

--- a/fit-vids.js
+++ b/fit-vids.js
@@ -20,7 +20,7 @@ export class FitVids extends HTMLElement {
   }
 
   connectedCallback() {
-    this.querySelectorAll("iframe").forEach((video) => {
+    this.querySelectorAll("iframe[height][width]").forEach((video) => {
       // 🪄✨ Sprinkle the magic
       video.style.setProperty("--w", video.getAttribute("width"));
       video.style.setProperty("--h", video.getAttribute("height"));

--- a/fit-vids.js
+++ b/fit-vids.js
@@ -1,18 +1,29 @@
-class FitVids extends HTMLElement {
-  connectedCallback() {
-    const videoSources = ['iframe[src*="youtube"]', 'iframe[src*="vimeo"]'];
-    this.style.display = "block";
+export class FitVids extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+        }
 
-    this.querySelectorAll(videoSources.join(",")).forEach((video) => {
-      // ↔️ Make it go big
-      video.style.width = "100%";
-      video.style.height = "auto";
-      // 🔛 But not too big
-      video.style.maxWidth = "100%";
+        ::slotted(iframe) {
+          aspect-ratio: var(--w, 16) / var(--h, 9);
+          height: auto;
+          max-width: 100%;
+          width: 100%;
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+
+  connectedCallback() {
+    this.querySelectorAll("iframe").forEach((video) => {
       // 🪄✨ Sprinkle the magic
-      video.style.aspectRatio = `${video.getAttribute(
-        "width"
-      )} / ${video.getAttribute("height")}`;
+      video.style.setProperty("--w", video.getAttribute("width"));
+      video.style.setProperty("--h", video.getAttribute("height"));
       // 🐾 Leave no trace
       video.removeAttribute("height");
       video.removeAttribute("width");
@@ -20,8 +31,6 @@ class FitVids extends HTMLElement {
   }
 }
 
-if("customElements" in window) {
-	window.customElements.define("fit-vids", FitVids);
+if ("customElements" in window) {
+  window.customElements.define("fit-vids", FitVids);
 }
-
-export { FitVids };


### PR DESCRIPTION
### Why?

- Closes #1 

### What?

- [x] Support more sources by NOT caring what kind of `iframe` is passed in.
- [x] Move styles to Shadow DOM for less inline styles and more encapsulation.
- [x] Still tiny 889b → 482b (gzip)
- [x] Change `export` strategy